### PR TITLE
controller: add pluggable error and panic handlers

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -46,6 +46,9 @@ type Context interface {
 	Recorder() events.Recorder
 }
 
+type ControllerSyncPanicFn func(interface{}) error
+type ControllerSyncErrorFn func(error) error
+
 // ControllerSyncFn is a function that contain main controller logic.
 // The syncContext.syncContext passed is the main controller syncContext, when cancelled it means the controller is being shut down.
 // The syncContext provides access to controller name, queue and event recorder.


### PR DESCRIPTION
This introduces `WithSyncErrorHandler` and `WithSyncPanicHandler` which provides a registration mechanism for custom error and panic handler for the controller `sync()` function.

It allows to custom error processing, reporting or metrics gathering.